### PR TITLE
Reworked Map Rotation

### DIFF
--- a/config/example/maps.txt
+++ b/config/example/maps.txt
@@ -14,44 +14,40 @@ endmap
 
 map lv624
 	default
-	minplayers 25
+	minplayers 1
 endmap
 
 map bigred_v2
 	minplayers 25
-endmap
-
-map ice_colony_v2
-	minplayers 40
-endmap
-
-map prison_station_fop
-	minplayers 20
 	maxplayers 60
 endmap
 
-map vapor_processing
+map ice_colony_v2
+	minplayers 25
+	maxplayers 60
+endmap
+
+map prison_station_fop
+	minplayers 25
+	maxplayers 60
 endmap
 
 map icy_caves
-	maxplayers 50
+    minplayers 25
+	maxplayers 60
 endmap
 
 map research_outpost
-	maxplayers 40
+    minplayers 1
+	maxplayers 25
 endmap
 
 map barrenquilla_mining
-	minplayers 30
-	maxplayers 80
-endmap
-
-map whiskey_outpost_v2
+	minplayers 1
+	maxplayers 25
 endmap
 
 map magmoor_digsite_iv
-	minplayers 20
-endmap
-
-map marine_hq
+	minplayers 1
+	maxplayers 25
 endmap


### PR DESCRIPTION
About The Pull Request
Essentially at the request of a individual I have changed the rotation inside the maps.txt folder to which smaller maps require a minplayer count of 1 and a max of 25 while bigger maps required a min of 25 and a max of 60. I also removed several maps from rotation that were broken, Whisky, Vapor and Marine HQ.

Why It's Good For The Game
Essentially it just helps out in preventing the selection of large maps and trys to stay in a small range so xenos and marines can interact more.

Changelog
Changed: Min and Max values.
Removed: Whisky, Vaper, and Marine HQ from selection.